### PR TITLE
Make "MapToolbarEnabled" true

### DIFF
--- a/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.GoogleMaps/Xamarin.Forms.GoogleMaps.Android/MapRenderer.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.GoogleMaps.Android
                 map.SetOnMapClickListener(this);
                 map.SetOnMapLongClickListener(this);
                 map.SetOnMyLocationButtonClickListener(this);
-                map.UiSettings.MapToolbarEnabled = false;
+                map.UiSettings.MapToolbarEnabled = true;
                 map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
                 map.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
                 map.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;


### PR DESCRIPTION
I would like to use "MapToolbar". I am using GitHub for the first time, so I'm sorry if I used it incorrectly.

 / Xamarin.Forms.GoogleMaps / Xamarin.Forms.GoogleMaps.Android / MapRenderer.cs 

`146                 map.UiSettings.MapToolbarEnabled = false; `
   ↓
`146                 map.UiSettings.MapToolbarEnabled = true; `